### PR TITLE
Finalize project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 package-lock.json
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
-cache/
 node_modules/
 .vscode
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules
+.idea/
+cache/
+node_modules/
 .vscode
 package-lock.json
-.idea/

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This plugin is a WIP, check below for the current limitations.
 
 ## WIP
 - Currently no password support for MiLight Hub or MQTT server
-- Currently only RGB(W) lamps have been confirmed to work, others *might* work as well
-- Currently no backchannel, HomeKit doesn't update if MiLight hub is controlled otherwise
+- Currently only RGB(W) + RGB+CCT lamps have been confirmed to work, others *might* work as well
+- Currently no backchannel for mqtt, HomeKit doesn't update if MiLight hub is controlled otherwise
 
 ## Installation
 1. Install homebridge using: npm install -g homebridge
@@ -39,6 +39,10 @@ This plugin is a WIP, check below for the current limitations.
 
 #### Options
  - `host` Hostname of your MiLight Hub, default `milight-hub.local`
+ - `backchannel` Enables/Disables backchannel, currently limited to http only, default `false` (disabled)
+ - `rgbcct_mode` Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favorite colors in Home App anymore, default `false` (disabled)
+ --- further explanation at the bottom
+ - `debug` Enables/Disables debug mode, default `false` (disabled)
 
 ## Usage
 #### Adding/removing Lamps
@@ -46,3 +50,8 @@ To add lamps in HomeKit, add aliases to the MiLight Hub. The aliases will automa
 
 #### Using MQTT
 If MQTT is configured in the MiLight Hub then the plugin will automatically read those settings and use them to connect to MiLight Hub via MQTT. Make sure your MQTT topic pattern includes the `:device_id`, `:device_type` and `:group_id` values, as in the suggested default value `milight/:device_id/:device_type/:group_id`.
+
+
+## Limitation
+#### RGB+CCT lamps
+RGB+CCT (or RGBWW) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both rgb and kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favorite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This plugin is a WIP, check below for the current limitations.
 ## WIP
 - Currently no password support for MiLight Hub or MQTT server
 - Currently only RGB(W) + RGB+CCT lamps have been confirmed to work, others *might* work as well
-- Currently no backchannel for mqtt, HomeKit doesn't update if MiLight hub is controlled otherwise
 
 ## Installation
 1. Install homebridge using: npm install -g homebridge

--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ This plugin is a WIP, check below for the current limitations.
 - Currently no password support for MiLight Hub or MQTT server
 - Currently only RGB(W) + RGB+CCT lamps have been confirmed to work, others *might* work as well
 - Currently no backchannel for mqtt, HomeKit doesn't update if MiLight hub is controlled otherwise
-- Currently some options like backchannel, rgbcctMode need a manual re-add of accessories before being active. 
-If you don't do a re-add they may behave weird or the plugin may crash.
-Re-adding is done as follows: Go to your Milight Hub, select an alias and remove it.
-Wait until you see that the accessory was deleted in the homebridge logs.
-After that add it again. Repeat above steps for every alias.
 
 ## Installation
 1. Install homebridge using: npm install -g homebridge

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This plugin is a WIP, check below for the current limitations.
 - Currently no password support for MiLight Hub or MQTT server
 - Currently only RGB(W) + RGB+CCT lamps have been confirmed to work, others *might* work as well
 - Currently no backchannel for mqtt, HomeKit doesn't update if MiLight hub is controlled otherwise
+- Some options like backchannel, rgbcctMode need a manual re-add of accessories before being active. 
+If you don't do a re-add they may behave weird or the application may crash.
+Re-adding is done as follows: Go to your Milight Hub, select an alias and remove it.
+Wait until you see that the accessory was deleted in the homebridge logs.
+After that add it again. Repeat above steps for every alias.
 
 ## Installation
 1. Install homebridge using: npm install -g homebridge

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This plugin is a WIP, check below for the current limitations.
 - Currently no password support for MiLight Hub or MQTT server
 - Currently only RGB(W) + RGB+CCT lamps have been confirmed to work, others *might* work as well
 - Currently no backchannel for mqtt, HomeKit doesn't update if MiLight hub is controlled otherwise
-- Some options like backchannel, rgbcctMode need a manual re-add of accessories before being active. 
-If you don't do a re-add they may behave weird or the application may crash.
+- Currently some options like backchannel, rgbcctMode need a manual re-add of accessories before being active. 
+If you don't do a re-add they may behave weird or the plugin may crash.
 Re-adding is done as follows: Go to your Milight Hub, select an alias and remove it.
 Wait until you see that the accessory was deleted in the homebridge logs.
 After that add it again. Repeat above steps for every alias.

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ If MQTT is configured in the MiLight Hub then the plugin will automatically read
 
 
 ## Limitation
-#### RGB+CCT lamps
-RGB+CCT (or RGBWW) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.
+#### RGB+CCT / RGBW(W) lamps
+RGB+CCT / RGBW(W) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ To add lamps in HomeKit, add aliases to the MiLight Hub. The aliases will automa
 #### Using MQTT
 If MQTT is configured in the MiLight Hub then the plugin will automatically read those settings and use them to connect to MiLight Hub via MQTT. Make sure your MQTT topic pattern includes the `:device_id`, `:device_type` and `:group_id` values, as in the suggested default value `milight/:device_id/:device_type/:group_id`.
 
-
 ## Limitation
 #### RGB+CCT / RGBW(W) lamps
 RGB+CCT / RGBW(W) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ This plugin is a WIP, check below for the current limitations.
 #### Options
  - `host` Hostname of your MiLight Hub, default `milight-hub.local`
  - `backchannel` Enables/Disables backchannel, currently limited to http only, default `false` (disabled)
- - `rgbcct_mode` Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favorite colors in Home App anymore, default `false` (disabled)
- --- further explanation at the bottom
+ - `rgbcctMode` Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favourite colors in Home App anymore, default `false` (disabled)
+ --- further explanation at the bottom 
+ - `forceHTTP` Force use of HTTP regardless of MQTT settings in your MiLight hub, default `false` (disabled)
  - `debug` Enables/Disables debug mode, default `false` (disabled)
 
 ## Usage
@@ -54,4 +55,4 @@ If MQTT is configured in the MiLight Hub then the plugin will automatically read
 
 ## Limitation
 #### RGB+CCT lamps
-RGB+CCT (or RGBWW) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both rgb and kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favorite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.
+RGB+CCT (or RGBWW) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ This plugin is a WIP, check below for the current limitations.
 - Automatically uses MQTT if configured in the MiLight Hub
   - Using an MQTT broker can improve performance when using many lamps
 
-## WIP
-- Currently no password support for MiLight Hub or MQTT server
-- Currently only RGB(W) + RGB+CCT lamps have been confirmed to work, others *might* work as well
-
 ## Installation
 1. Install homebridge using: npm install -g homebridge
 2. Install this plugin using: npm install -g homebridge-milighthub-platform
@@ -41,6 +37,8 @@ This plugin is a WIP, check below for the current limitations.
  - `backchannel` Enables/Disables backchannel, currently limited to http only, default `false` (disabled)
  - `rgbcctMode` Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favourite colors in Home App anymore, default `false` (disabled)
  --- further explanation at the bottom 
+ - `httpUsername` If you are using a username:password authentication for your MiLight Hub type in here your credentials, default `null` (disabled)
+ - `httpPassword` If you are using a username:password authentication for your MiLight Hub type in here your credentials, default `null` (disabled)
  - `forceHTTP` Force use of HTTP regardless of MQTT settings in your MiLight hub, default `false` (disabled)
  - `debug` Enables/Disables debug mode, default `false` (disabled)
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -19,21 +19,28 @@
       "required": false
     },
     "backchannel": {
-      "title": "Backchannel",
+      "title": "Backchannel enabled",
       "type": "boolean",
       "default": false,
       "description": "If enabled HomeKit does update if MiLight hub is controlled otherwise, currently limited to http only",
       "required": false
     },
-    "rgbcct_mode": {
-      "title": "RGB+CCT mode",
+    "rgbcctMode": {
+      "title": "RGB+CCT mode enabled",
       "type": "boolean",
       "default": false,
       "description": "Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favorite colors in Home App anymore.",
       "required": false
     },
+    "forceHTTP": {
+      "title": "Force HTTP instaed of MQTT",
+      "type": "boolean",
+      "default": false,
+      "description": "Force use of HTTP regardless of mqtt settings in your MiLight hub",
+      "required": false
+    },
     "debug": {
-      "title": "Debug mode",
+      "title": "Debug mode enabled",
       "type": "boolean",
       "default": false,
       "description": "Enables debug mode",

--- a/config.schema.json
+++ b/config.schema.json
@@ -36,7 +36,7 @@
       "title": "Force HTTP instaed of MQTT",
       "type": "boolean",
       "default": false,
-      "description": "Force use of HTTP regardless of mqtt settings in your MiLight hub",
+      "description": "Force use of HTTP regardless of MQTT settings in your MiLight hub",
       "required": false
     },
     "debug": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -17,6 +17,27 @@
       "default": "milight-hub.local",
       "description": "The hostname or IP address of the MiLight Hub",
       "required": false
+    },
+    "backchannel": {
+      "title": "Backchannel",
+      "type": "boolean",
+      "default": false,
+      "description": "If enabled HomeKit does update if MiLight hub is controlled otherwise, currently limited to http only",
+      "required": false
+    },
+    "rgbcct_mode": {
+      "title": "RGB+CCT mode",
+      "type": "boolean",
+      "default": false,
+      "description": "Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favorite colors in Home App anymore.",
+      "required": false
+    },
+    "debug": {
+      "title": "Debug mode",
+      "type": "boolean",
+      "default": false,
+      "description": "Enables debug mode",
+      "required": false
     }
   }
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -18,6 +18,20 @@
       "description": "The hostname or IP address of the MiLight Hub",
       "required": false
     },
+    "httpUsername": {
+      "title": "Authorization: HTTP Username",
+      "type": "string",
+      "default": "",
+      "description": "If you are using a username:password authentication for your MiLight Hub type in here your credentials",
+      "required": false
+    },
+    "httpPassword": {
+      "title": "Authorization: HTTP Password",
+      "type": "string",
+      "default": "",
+      "description": "If you are using a username:password authentication for your MiLight Hub type in here your credentials",
+      "required": false
+    },
     "backchannel": {
       "title": "Backchannel enabled",
       "type": "boolean",

--- a/index.js
+++ b/index.js
@@ -150,15 +150,24 @@ class MiLightHubPlatform {
           // already exists
           found = true;
 
-          if(found && platform.characteristicDetails !== JSON.parse(milight.characteristics)[HAPModelCharacteristic].value){
+          if(found && platform.characteristicDetails !== milight.characteristics[HAPModelCharacteristic].value){
             this.debugLog('Characteristics mismatch detected, Removing accessory!');
             characteristicsMatch = false;
           }
+
         }
       });
 
       if (!found || !characteristicsMatch) {
-        this.log('Removing ' + milight.name + ' from Homekit');
+        let removeMessage = 'Removing ' + milight.name + ' from Homekit because ';
+
+        if(!found){
+          removeMessage += 'it could not be find in MiLight Hub';
+        } else {
+          removeMessage += 'a characteristics mismatch was detected';
+        }
+
+        this.log(removeMessage);
         this.accessories.splice(idx, 1);
 
         this.api.unregisterPlatformAccessories('homebridge-milighthub-platform', 'MiLightHubPlatform', [milight.accessory]);
@@ -271,8 +280,6 @@ class MiLightHubPlatform {
 
       return this.cachedPromises[path + "_promise"];
     }
-
-
   }
 
   //RGBtoHSV by Garry Tan from https://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c with some modifications
@@ -335,7 +342,7 @@ class MiLight {
       }
     }
 
-    this.characteristics = JSON.stringify(this.characteristics);
+    this.characteristics = JSON.parse(JSON.stringify(this.characteristics));
 
     this.myTimeout = null;
   }

--- a/index.js
+++ b/index.js
@@ -54,6 +54,25 @@ class MiLightHubPlatform {
     callback(null);
   }
 
+  debugLog (message) {
+    if (!this.debug) {
+      return;
+    }
+
+    const debugLogDelimiter = 'DEBUG: ';
+    if (Array.isArray(message)) {
+      for (var i = 0, len = message.length; i < len; i++) {
+        if (i === 0) {
+          this.log(debugLogDelimiter, message[i]);
+        } else {
+          console.log(message[i])
+        }
+      }
+    } else {
+      this.log(debugLogDelimiter, message);
+    }
+  }
+
   getServerLightList () {
     const platform = this;
     this.readHubSettings(this.host).then(response => {

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ class MiLightHubPlatform {
 
   async sendHttp (path, json) {
     return new Promise(resolve => {
-      const url = 'http://' + this.host + path;
+      const url = 'http://' + this.host + '/gateways/' + path;
       const sendBody = JSON.stringify(json);
       const req = http.request(url, {
         method: 'PUT',
@@ -194,7 +194,7 @@ class MiLightHubPlatform {
         });
       });
       req.on('error', e => {
-        console.log('error sending to Milight esp hub', url, e);
+        // console.log('error sending to Milight esp hub', url, json, e);
         resolve(false);
       });
       req.write(sendBody);
@@ -204,7 +204,7 @@ class MiLightHubPlatform {
 
   async getHttp (path) {
     return new Promise(resolve => {
-      const url = 'http://' + this.host + '/gateways/' + path + '?blockOnQueue=true';
+      const url = 'http://' + this.host + path;
       const req = http.request(url, {
         method: 'GET'
       }, res => {
@@ -222,7 +222,7 @@ class MiLightHubPlatform {
         });
       });
       req.on('error', e => {
-        // console.log('error sending to Milight esp hub', url, json, e);
+        console.log('error sending to Milight esp hub', url, e);
         resolve(false);
       });
       req.end();

--- a/index.js
+++ b/index.js
@@ -499,7 +499,7 @@ class MiLight {
 
   /** MiLight shiz */
   async getPowerState (callback) {
-    if (this.mqttClient) {
+    if (this.platform.mqttClient) {
       // TODO: implement getPowerState via MQTT
       //not implemented yet so return null
       callback(null, null);
@@ -525,7 +525,7 @@ class MiLight {
   async getBrightness (callback) {
     var brightness;
 
-    if (this.mqttClient) {
+    if (this.platform.mqttClient) {
       // TODO: implement getBrightness via MQTT
       // not implemented yet so return null
       callback(null, null);
@@ -555,7 +555,7 @@ class MiLight {
   }
 
   async getHue (callback) {
-    if (this.mqttClient) {
+    if (this.platform.mqttClient) {
       // TODO: implement getHue via MQTT
       //not implemented yet so return null
       callback(null, null);
@@ -584,7 +584,7 @@ class MiLight {
   }
 
   async getSaturation (callback) {
-    if (this.mqttClient) {
+    if (this.platform.mqttClient) {
       // TODO: implement getSaturation via MQTT
       //not implemented yet so return null
       callback(null, null);
@@ -613,7 +613,7 @@ class MiLight {
   }
 
   async getColorTemperature (callback) {
-    if (this.mqttClient) {
+    if (this.platform.mqttClient) {
       // TODO: implement getBrightness via MQTT
       // not implemented yet so return null
       callback(null, null);

--- a/index.js
+++ b/index.js
@@ -406,13 +406,11 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = await this.platform.getHttp(path);
+      var returnValue = JSON.parse(await this.platform.getHttp(path));
 
-      this.platform.debugLog(['\n', 'GET Request: ' + path, 'returned JSON Object: ', JSON.parse(returnValue)]);
+      this.platform.debugLog(['\n', 'GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 
-      var state = JSON.parse(returnValue).state;
-
-      callback(null, state === "ON");
+      callback(null, returnValue.state === 'ON' || returnValue.bulb_mode === 'night');
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class MiLightHubPlatform {
     // controlling them in RGB+CCT mode lets the color saving / favorite function to malfunction
     this.rgbcctMode = config.rgbcctMode === null ? false : this.rgbcctMode = config.rgbcctMode !== false;
 
-    this.rgbcctRemotes = ['rgbw', 'cct', 'fut091'];
+    this.rgbRemotes = ['rgbw', 'cct', 'fut091'];
     this.rgbcctRemotes = ['fut089', 'cct', 'rgb_cct'];
 
     this.cachedPromises = [];

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class MiLightHubPlatform {
     // but let the user choose because the RGB+CCT lamps do have seperate LEDs for the white temperatures and seperate for the RGB colors
     // controlling them in RGB mode lets seem the RGB screen to be buggy (orange colors will sometimes change to white_mode)
     // controlling them in RGB+CCT mode lets the color saving / favorite function to malfunction
-    this.rgbcct_mode = config['rgbcct_mode'] === null ? false : this.rgbcct_mode = config['rgbcct_mode'] !== false;
+    this.rgbcctMode = config['rgbcctMode'] === null ? false : this.rgbcctMode = config['rgbcctMode'] !== false;
 
     this.cachedPromises = [];
 
@@ -325,7 +325,7 @@ class MiLight {
       lightbulbService.addCharacteristic(new Characteristic.Hue());
     }
 
-    if (this.platform.rgbcct_mode && ['fut089', 'cct', 'rgb_cct'].indexOf(this.remote_type) > -1) {
+    if (this.platform.rgbcctMode && ['fut089', 'cct', 'rgb_cct'].indexOf(this.remote_type) > -1) {
       lightbulbService
           .addCharacteristic(new Characteristic.ColorTemperature())
           // maxValue 370 = 2700K (1000000/2700)
@@ -391,7 +391,7 @@ class MiLight {
     }
 
 
-    if(this.platform.rgbcct_mode && (lightbulbService.getCharacteristic(Characteristic.ColorTemperature))) {
+    if(this.platform.rgbcctMode && (lightbulbService.getCharacteristic(Characteristic.ColorTemperature))) {
       this.platform.debugLog('Characteristic.ColorTemperature is set');
 
       if(this.platform.backchannel) {
@@ -465,7 +465,7 @@ class MiLight {
       cstate.hue = dstate.hue;
     }
 
-    if(!this.platform.rgbcct_mode){
+    if(!this.platform.rgbcctMode){
       let useWhiteMode = this.testWhiteMode(dstate.hue, dstate.saturation);
       if(useWhiteMode){
         delete command.saturation;

--- a/index.js
+++ b/index.js
@@ -258,7 +258,9 @@ class MiLightHubPlatform {
 
   //RGBtoHSV by Garry Tan from https://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c with some modifications
   RGBtoHS(r, g, b) {
-    var max = Math.max(r, g, b), min = Math.min(r, g, b), a = max - min;
+    const max = Math.max(r, g, b),
+          min = Math.min(r, g, b),
+          a = max - min;
 
     switch(max) {
       case min:
@@ -502,7 +504,7 @@ class MiLight {
     }
   }
 
-  setHue (value, callback, context) {
+  setHue (value, callback) {
     this.designatedState.hue = value;
     this.stateChange();
     callback(null);

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class MiLightHubPlatform {
     var platform = this;
     this.log = log;
     this.config = config;
+    this.debug = config['debug'] || false;
 
     // TODO: settings
     this.host = config.host || 'milight-hub.local';

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class MiLightHubPlatform {
 
   getServerLightList () {
     const platform = this;
-    this.getHttp('/settings').then(response => {
+    this.apiCall('/settings').then(response => {
       if (response) {
         var lightList = [];
         const settings = JSON.parse(response);
@@ -164,50 +164,33 @@ class MiLightHubPlatform {
       }
       return true;
     } else {
-      var path = '0x' + deviceId.toString(16) + '/' + remoteType + '/' + groupId;
-      this.sendHttp(path, command);
+      var path = '/gateways/' + '0x' + deviceId.toString(16) + '/' + remoteType + '/' + groupId;
+      this.apiCall(path, command);
       this.log(path, command);
     }
   }
 
-  async sendHttp (path, json) {
-    return new Promise(resolve => {
-      const url = 'http://' + this.host + '/gateways/' + path;
-      const sendBody = JSON.stringify(json);
-      const req = http.request(url, {
-        method: 'PUT',
-        headers: {
-          'Content-Length': sendBody.length
-        }
-      }, res => {
-        let recvBody = '';
-        res.on('data', chunk => {
-          recvBody += chunk;
-        });
-        res.on('end', _ => {
-          // console.log("response end, status: "+res.statusCode+" recvBody: "+recvBody);
-          if (res.statusCode === 200) {
-            resolve(true);
-          } else {
-            resolve(false);
-          }
-        });
-      });
-      req.on('error', e => {
-        // console.log('error sending to Milight esp hub', url, json, e);
-        resolve(false);
-      });
-      req.write(sendBody);
-      req.end();
-    });
-  }
 
-  async getHttp (path) {
+  async apiCall (path, json = null) {
     return new Promise(resolve => {
       const url = 'http://' + this.host + path;
-      const req = http.request(url, {
-        method: 'GET'
-      }, res => {
+
+      var http_header;
+      if(json === null){
+        http_header ={
+          method: 'GET'
+        };
+      } else {
+        var sendBody = JSON.stringify(json);
+        http_header ={
+          method: 'PUT',
+          headers: {
+            'Content-Length': sendBody.length
+          }
+        };
+      }
+
+      const req = http.request(url, http_header, res => {
         let recvBody = '';
         res.on('data', chunk => {
           recvBody += chunk;
@@ -222,9 +205,16 @@ class MiLightHubPlatform {
         });
       });
       req.on('error', e => {
-        console.log('error sending to Milight esp hub', url, e);
+        if(json === null){
+          console.log('error sending to Milight esp hub', url, json, e);
+        } else {
+          console.log('error sending to Milight esp hub', url, e);
+        }
         resolve(false);
       });
+      if(json !== null){
+        req.write(sendBody);
+      }
       req.end();
     });
   }
@@ -439,7 +429,7 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.getHttp(path));
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['\n', '[getPowerState] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 
@@ -462,7 +452,7 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.getHttp(path));
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['\n', '[getBrightness] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 
@@ -489,7 +479,7 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.getHttp(path));
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['\n', '[getHue] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 
@@ -515,7 +505,7 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.getHttp(path));
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['\n', '[getSaturation] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 
@@ -541,7 +531,7 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.getHttp(path));
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['\n', '[getColorTemperature] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 

--- a/index.js
+++ b/index.js
@@ -23,16 +23,16 @@ class MiLightHubPlatform {
     var platform = this;
     this.log = log;
     this.config = config;
-    this.backchannel = config['backchannel'] || false;
-    this.forceHTTP = config['forceHTTP'] || false;
-    this.debug = config['debug'] || false;
+    this.backchannel = config.backchannel || false;
+    this.forceHTTP = config.forceHTTP || false;
+    this.debug = config.debug || false;
 
     // according to https://github.com/apple/HomeKitADK/blob/master/HAP/HAPCharacteristicTypes.h this is a unsupported combination:
     // "This characteristic must not be used for lamps which support color."
     // but let the user choose because the RGB+CCT lamps do have seperate LEDs for the white temperatures and seperate for the RGB colors
     // controlling them in RGB mode lets seem the RGB screen to be buggy (orange colors will sometimes change to white_mode)
     // controlling them in RGB+CCT mode lets the color saving / favorite function to malfunction
-    this.rgbcctMode = config['rgbcctMode'] === null ? false : this.rgbcctMode = config['rgbcctMode'] !== false;
+    this.rgbcctMode = config.rgbcctMode === null ? false : this.rgbcctMode = config.rgbcctMode !== false;
 
     this.cachedPromises = [];
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@ const packageJSON = require('./package.json');
 
 var http = require('http');
 var mqtt = require('mqtt');
-var fs   = require('fs');
-var path = require('path');
 
 var Accessory, Service, Characteristic, UUIDGen;
 

--- a/index.js
+++ b/index.js
@@ -177,9 +177,8 @@ class MiLightHubPlatform {
       return true;
     } else {
       var path = '/gateways/' + '0x' + deviceId.toString(16) + '/' + remoteType + '/' + groupId;
-      this.debugLog(['Sending PUT request to: ' + path, command]);
+      this.log('SENT: ' + path, command);
       this.apiCall(path, command);
-      this.log(path, command);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ class MiLightHubPlatform {
 
     this.cachedPromises = [];
 
-    // TODO: settings
     this.host = config.host || 'milight-hub.local';
     this.accessories = [];
 
@@ -120,7 +119,6 @@ class MiLightHubPlatform {
             platform.mqttClient.end();
             platform.mqttClient = null;
           }
-          // TODO: user / pass
           if (platform.mqttServer && !(platform.forceHTTP)) {
             platform.log('Using MQTT server at ' + platform.mqttServer);
             this.initializeMQTT();
@@ -582,7 +580,6 @@ class MiLight {
   }
 
   applyDesignatedState () {
-    // this.myTimeout = null;
     const dstate = this.designatedState;
     const cstate = this.currentState;
     this.designatedState = {};

--- a/index.js
+++ b/index.js
@@ -187,6 +187,11 @@ class MiLightHubPlatform {
   }
 
   async apiCall (path, json = null, func) {
+    // MiLight Hub lets you know all properties of the device on one HTTP request.
+    // Unfortunately HomeKit queries each characteristic separately, so we've build a dedup function
+    // It looks if the current job is already in Promise state 'PENDING' (running)
+    // If yes return the same promise from cache --> don't start a new one(!)
+    // If no start a promise, cache it and return this
     if (this.cachedPromises[path] === 'PENDING'){
       this.debugLog('GET (dedup): ' + path);
       return await this.cachedPromises[path + '_promise'];

--- a/index.js
+++ b/index.js
@@ -110,6 +110,8 @@ class MiLightHubPlatform {
           if (platform.mqttServer) {
             platform.log('Using MQTT server at ' + platform.mqttServer);
             platform.mqttClient = mqtt.connect('mqtt://' + platform.mqttServer);
+          } else {
+            platform.log('Using HTTP server at ' + platform.host);
           }
         }
         for (var name in settings.group_id_aliases) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const packageJSON = require('./package.json');
 
 var http = require('http');
 var mqtt = require('mqtt');
+
 var Accessory, Service, Characteristic, UUIDGen;
 
 
@@ -88,7 +89,10 @@ class MiLightHubPlatform {
 
   getServerLightList () {
     const platform = this;
-    this.apiCall('/settings').then(response => {
+    const settings_path = '/settings';
+
+    this.debugLog('Querying ' + settings_path);
+    this.apiCall(settings_path).then(response => {
       if (response) {
         var lightList = [];
         const settings = JSON.parse(response);
@@ -173,8 +177,8 @@ class MiLightHubPlatform {
       return true;
     } else {
       var path = '/gateways/' + '0x' + deviceId.toString(16) + '/' + remoteType + '/' + groupId;
+      this.debugLog(['Sending PUT request to: ' + path, command]);
       this.apiCall(path, command);
-      this.log(path, command);
     }
   }
 
@@ -251,6 +255,8 @@ class MiLightHubPlatform {
       s: Math.round(100 * (0 === max ? 0 : a / max))
     };
   }
+
+
 }
 
 class MiLight {
@@ -476,7 +482,7 @@ class MiLight {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.apiCall(path));
 
-      this.platform.debugLog(['[getPowerState] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+      this.platform.debugLog(['[getPowerState] GET Request']);
 
       callback(null, returnValue.state === 'ON' || returnValue.bulb_mode === 'night');
     }
@@ -502,7 +508,7 @@ class MiLight {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.apiCall(path));
 
-      this.platform.debugLog(['[getBrightness] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+      this.platform.debugLog(['[getBrightness] GET Request']);
 
       if(returnValue.bulb_mode === 'night'){
         brightness = 1; //set brightness to 1 if night_mode is enabled
@@ -532,7 +538,7 @@ class MiLight {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.apiCall(path));
 
-      this.platform.debugLog(['[getHue] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+      this.platform.debugLog(['[getHue] GET Request']);
 
       if(returnValue.bulb_mode === "color"){
         var calculatedHS = this.platform.RGBtoHS(returnValue.color.r, returnValue.color.g, returnValue.color.b);
@@ -561,7 +567,7 @@ class MiLight {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.apiCall(path));
 
-      this.platform.debugLog(['[getSaturation] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+      this.platform.debugLog(['[getSaturation] GET Request']);
 
       if(returnValue.bulb_mode === "color"){
         var calculatedHS = this.platform.RGBtoHS(returnValue.color.r, returnValue.color.g, returnValue.color.b);
@@ -590,7 +596,7 @@ class MiLight {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.apiCall(path));
 
-      this.platform.debugLog(['[getColorTemperature] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+      this.platform.debugLog(['[getColorTemperature] GET Request']);
 
       if(returnValue.bulb_mode === "color"){
         callback(null, null);

--- a/index.js
+++ b/index.js
@@ -308,59 +308,63 @@ class MiLight {
 
   applyCallbacks (accessory) {
     const lightbulbService = accessory.getService(Service.Lightbulb);
+
     if (!lightbulbService) {
       this.log('Error: unconfigured accessory without light service found.');
       return;
     }
+
     if (lightbulbService.getCharacteristic(Characteristic.On)) {
+      this.platform.debugLog('Characteristic.On is set');
       if(this.platform.backchannel) {
         lightbulbService.getCharacteristic(Characteristic.On)
-            .on('get', this.getPowerState.bind(this))
-            .on('set', this.setPowerState.bind(this));
-      } else {
-        lightbulbService.getCharacteristic(Characteristic.On)
-            .on('set', this.setPowerState.bind(this));
+            .on('get', this.getPowerState.bind(this));
       }
+      lightbulbService.getCharacteristic(Characteristic.On)
+          .on('set', this.setPowerState.bind(this));
     }
+
     if (lightbulbService.getCharacteristic(Characteristic.Brightness)) {
+      this.platform.debugLog('Characteristic.Brightness is set');
       if(this.platform.backchannel) {
         lightbulbService.getCharacteristic(Characteristic.Brightness)
-            .on('get', this.getBrightness.bind(this))
-            .on('set', this.setBrightness.bind(this));
-      } else {
-        lightbulbService.getCharacteristic(Characteristic.Brightness)
-            .on('set', this.setBrightness.bind(this));
+            .on('get', this.getBrightness.bind(this));
       }
+      lightbulbService.getCharacteristic(Characteristic.Brightness)
+          .on('set', this.setBrightness.bind(this));
     }
+
     if (lightbulbService.getCharacteristic(Characteristic.Hue)) {
+      this.platform.debugLog('Characteristic.Hue is set');
+
       if(this.platform.backchannel) {
         lightbulbService.getCharacteristic(Characteristic.Hue)
-            .on('get', this.getHue.bind(this))
-            .on('set', this.setHue.bind(this));
-      } else {
-        lightbulbService.getCharacteristic(Characteristic.Hue)
-            .on('set', this.setHue.bind(this));
+            .on('get', this.getHue.bind(this));
       }
+      lightbulbService.getCharacteristic(Characteristic.Hue)
+          .on('set', this.setHue.bind(this));
     }
+
     if (lightbulbService.getCharacteristic(Characteristic.Saturation)) {
+      this.platform.debugLog('Characteristic.Saturation is set');
       if(this.platform.backchannel) {
         lightbulbService.getCharacteristic(Characteristic.Saturation)
-            .on('get', this.getSaturation.bind(this))
-            .on('set', this.setSaturation.bind(this));
-      } else {
-        lightbulbService.getCharacteristic(Characteristic.Saturation)
-            .on('set', this.setSaturation.bind(this));
+            .on('get', this.getSaturation.bind(this));
       }
+      lightbulbService.getCharacteristic(Characteristic.Saturation)
+          .on('set', this.setSaturation.bind(this));
     }
+
     if (lightbulbService.getCharacteristic(Characteristic.ColorTemperature)) {    // according to https://github.com/apple/HomeKitADK/blob/master/HAP/HAPCharacteristicTypes.h this is a unsupported combination: "This characteristic must not be used for lamps which support color." but adding it anyways because the RGB+CCT lamps do have seperate LEDs for the white temperatures and seperate for the RGB colors.
+      this.platform.debugLog('Characteristic.ColorTemperature is set');
+
       if(this.platform.backchannel) {
         lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
-            .on('get', this.getColorTemperature.bind(this))
-            .on('set', this.setColorTemperature.bind(this));
-      } else {
-        lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
-            .on('set', this.setColorTemperature.bind(this));
+            .on('get', this.getColorTemperature.bind(this));
       }
+      lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
+          .on('set', this.setColorTemperature.bind(this));
+
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -326,6 +326,7 @@ class MiLight {
     }
     if (lightbulbService.getCharacteristic(Characteristic.Brightness)) {
       lightbulbService.getCharacteristic(Characteristic.Brightness)
+          .on('get', this.getBrightness.bind(this))
           .on('set', this.setBrightness.bind(this));
     }
     if (lightbulbService.getCharacteristic(Characteristic.Saturation)) {
@@ -402,13 +403,14 @@ class MiLight {
   /** MiLight shiz */
   async getPowerState (callback) {
     if (this.mqttClient) {
+      // TODO: implement getPowerState via MQTT
       //not implemented yet so return null
       callback(null, null);
     } else {
       var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.getHttp(path));
 
-      this.platform.debugLog(['\n', 'GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+      this.platform.debugLog(['\n', '[getPowerState] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
 
       callback(null, returnValue.state === 'ON' || returnValue.bulb_mode === 'night');
     }
@@ -418,6 +420,29 @@ class MiLight {
     this.designatedState.state = powerOn;
     this.stateChange();
     callback(null);
+  }
+
+  async getBrightness (callback) {
+    var brightness;
+
+    if (this.mqttClient) {
+      // TODO: implement getBrightness via MQTT
+      // not implemented yet so return null
+      callback(null, null);
+    } else {
+      var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
+      var returnValue = JSON.parse(await this.platform.getHttp(path));
+
+      this.platform.debugLog(['\n', '[getBrightness] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
+
+      if(returnValue.bulb_mode === 'night'){
+        brightness = 1; //set brightness to 1 if night_mode is enabled
+      } else {
+        brightness = Math.round(returnValue.brightness/2.55); //rounding should not be necessary but implemented it to be safe
+      }
+
+      callback(null, brightness);
+    }
   }
 
   setBrightness (level, callback) {

--- a/index.js
+++ b/index.js
@@ -324,9 +324,7 @@ class MiLight {
     const lightbulbService = new Service.Lightbulb(this.name);
     lightbulbService.addCharacteristic(new Characteristic.Brightness());
 
-    // TODO: check types of remotes and corresponding characteristics
-    // TYPES: "rgbw" "cct" "rgb_cct" "rgb" "fut089" "fut091" "fut020"
-    if (['cct', 'fut091'].indexOf(this.remote_type) === -1) {
+    if (['rgbw', 'cct', 'fut091'].indexOf(this.remote_type) === -1) {
       lightbulbService.addCharacteristic(new Characteristic.Saturation());
       lightbulbService.addCharacteristic(new Characteristic.Hue());
     }

--- a/index.js
+++ b/index.js
@@ -228,9 +228,9 @@ class MiLightHubPlatform {
         });
         req.on('error', e => {
           if(json === null){
-            console.log('error sending to Milight esp hub', url, json, e);
+            console.log('Error sending to MiLight ESP hub', url, json, e);
           } else {
-            console.log('error sending to Milight esp hub', url, e);
+            console.log('Error sending to MiLight ESP hub', url, e);
           }
           resolve(false);
           this.cachedPromises[path] = 'new run';

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ class MiLightHubPlatform {
     var platform = this;
     this.log = log;
     this.config = config;
+    this.backchannel = config['backchannel'] === true || config['backchannel'] === null;
     this.debug = config['debug'] || false;
 
     // TODO: settings
@@ -350,29 +351,54 @@ class MiLight {
       return;
     }
     if (lightbulbService.getCharacteristic(Characteristic.On)) {
-      lightbulbService.getCharacteristic(Characteristic.On)
-          .on('get', this.getPowerState.bind(this))
-          .on('set', this.setPowerState.bind(this));
+      if(this.platform.backchannel) {
+        lightbulbService.getCharacteristic(Characteristic.On)
+            .on('get', this.getPowerState.bind(this))
+            .on('set', this.setPowerState.bind(this));
+      } else {
+        lightbulbService.getCharacteristic(Characteristic.On)
+            .on('set', this.setPowerState.bind(this));
+      }
     }
     if (lightbulbService.getCharacteristic(Characteristic.Brightness)) {
-      lightbulbService.getCharacteristic(Characteristic.Brightness)
-          .on('get', this.getBrightness.bind(this))
-          .on('set', this.setBrightness.bind(this));
+      if(this.platform.backchannel) {
+        lightbulbService.getCharacteristic(Characteristic.Brightness)
+            .on('get', this.getBrightness.bind(this))
+            .on('set', this.setBrightness.bind(this));
+      } else {
+        lightbulbService.getCharacteristic(Characteristic.Brightness)
+            .on('set', this.setBrightness.bind(this));
+      }
     }
     if (lightbulbService.getCharacteristic(Characteristic.Hue)) {
-      lightbulbService.getCharacteristic(Characteristic.Hue)
-          .on('get', this.getHue.bind(this))
-          .on('set', this.setHue.bind(this));
+      if(this.platform.backchannel) {
+        lightbulbService.getCharacteristic(Characteristic.Hue)
+            .on('get', this.getHue.bind(this))
+            .on('set', this.setHue.bind(this));
+      } else {
+        lightbulbService.getCharacteristic(Characteristic.Hue)
+            .on('set', this.setHue.bind(this));
+      }
     }
     if (lightbulbService.getCharacteristic(Characteristic.Saturation)) {
-      lightbulbService.getCharacteristic(Characteristic.Saturation)
-          .on('get', this.getSaturation.bind(this))
-          .on('set', this.setSaturation.bind(this));
+      if(this.platform.backchannel) {
+        lightbulbService.getCharacteristic(Characteristic.Saturation)
+            .on('get', this.getSaturation.bind(this))
+            .on('set', this.setSaturation.bind(this));
+      } else {
+        lightbulbService.getCharacteristic(Characteristic.Saturation)
+            .on('set', this.setSaturation.bind(this));
+      }
     }
-    if (lightbulbService.getCharacteristic(Characteristic.ColorTemperature)) {
-      lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
-          .on('get', this.getColorTemperature.bind(this))
-          .on('set', this.setColorTemperature.bind(this));
+    if (lightbulbService.getCharacteristic(Characteristic.ColorTemperature)) {    // according to https://github.com/apple/HomeKitADK/blob/master/HAP/HAPCharacteristicTypes.h this is a unsupported combination: "This characteristic must not be used for lamps which support color." but adding it anyways because the RGB+CCT lamps do have seperate LEDs for the white temperatures and seperate for the RGB colors.
+      if(this.platform.backchannel) {
+        lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
+            .on('get', this.getColorTemperature.bind(this))
+            .on('set', this.setColorTemperature.bind(this));
+      } else {
+        lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
+            .on('set', this.setColorTemperature.bind(this));
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -179,6 +179,7 @@ class MiLightHubPlatform {
       var path = '/gateways/' + '0x' + deviceId.toString(16) + '/' + remoteType + '/' + groupId;
       this.debugLog(['Sending PUT request to: ' + path, command]);
       this.apiCall(path, command);
+      this.log(path, command);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class MiLightHubPlatform {
       // Platform Plugin should only register new accessory that doesn't exist in homebridge after this event.
       // Or start discover new accessories.
       this.api.on('didFinishLaunching', function () {
-        // platform.log('DidFinishLaunching');
+        platform.debugLog('DidFinishLaunching');
         platform.getServerLightList();
       });
     }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
+const packageJSON = require('./package.json');
+
 var http = require('http');
 var mqtt = require('mqtt');
 var Accessory, Service, Characteristic, UUIDGen;
+
 
 module.exports = function (homebridge) {
   Accessory = homebridge.platformAccessory;
@@ -308,8 +311,9 @@ class MiLight {
     if (informationService) {
       informationService
           .setCharacteristic(Characteristic.Manufacturer, 'MiLight')
-          .setCharacteristic(Characteristic.Model, this.remote_type)
-          .setCharacteristic(Characteristic.SerialNumber, this.device_id + '[' + this.group_id + ']');
+          .setCharacteristic(Characteristic.Model, (accessory.context.light_info.remote_type).toUpperCase())
+          .setCharacteristic(Characteristic.SerialNumber, accessory.context.light_info.device_id + '[' + accessory.context.light_info.group_id + ']')
+          .setCharacteristic(Characteristic.FirmwareRevision, packageJSON.version);
     } else {
       this.log('Error: No information service found');
     }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class MiLightHubPlatform {
     this.accessories = [];
 
     if (api) {
-    // Save the API object as plugin needs to register new accessory via this object
+      // Save the API object as plugin needs to register new accessory via this object
       this.api = api;
 
       // Listen to event "didFinishLaunching", this means homebridge already finished loading cached accessories.
@@ -115,9 +115,9 @@ class MiLightHubPlatform {
       var found = false;
       this.accessories.forEach(milight => {
         if (milight.group_id === lightInfo.group_id &&
-          milight.device_id === lightInfo.device_id &&
-          milight.remote_type === lightInfo.remote_type &&
-          milight.name === lightInfo.name) {
+            milight.device_id === lightInfo.device_id &&
+            milight.remote_type === lightInfo.remote_type &&
+            milight.name === lightInfo.name) {
           found = true;
         }
       });
@@ -133,10 +133,10 @@ class MiLightHubPlatform {
       var found = false;
       lightList.forEach(lightInfo => {
         if (milight.group_id === lightInfo.group_id &&
-        milight.device_id === lightInfo.device_id &&
-        milight.remote_type === lightInfo.remote_type &&
-        milight.name === lightInfo.name) {
-        // already exists
+            milight.device_id === lightInfo.device_id &&
+            milight.remote_type === lightInfo.remote_type &&
+            milight.name === lightInfo.name) {
+          // already exists
           found = true;
         }
       });
@@ -256,9 +256,9 @@ class MiLight {
     const informationService = accessory.getService(Service.AccessoryInformation);// new Service.AccessoryInformation();
     if (informationService) {
       informationService
-        .setCharacteristic(Characteristic.Manufacturer, 'MiLight')
-        .setCharacteristic(Characteristic.Model, this.remote_type)
-        .setCharacteristic(Characteristic.SerialNumber, this.device_id + '[' + this.group_id + ']');
+          .setCharacteristic(Characteristic.Manufacturer, 'MiLight')
+          .setCharacteristic(Characteristic.Model, this.remote_type)
+          .setCharacteristic(Characteristic.SerialNumber, this.device_id + '[' + this.group_id + ']');
     } else {
       this.log('Error: No information service found');
     }
@@ -275,13 +275,13 @@ class MiLight {
 
     if (['fut089', 'cct', 'rgb_cct'].indexOf(this.remote_type) > -1) {
       lightbulbService
-        .addCharacteristic(new Characteristic.ColorTemperature())
-      // maxValue 370 = 2700K (1000000/2700)
-      // minValue 153 = 6500K (1000000/6500)
-        .setProps({
-          maxValue: 370,
-          minValue: 153
-        });
+          .addCharacteristic(new Characteristic.ColorTemperature())
+          // maxValue 370 = 2700K (1000000/2700)
+          // minValue 153 = 6500K (1000000/6500)
+          .setProps({
+            maxValue: 370,
+            minValue: 153
+          });
     }
     accessory.addService(lightbulbService);
   }
@@ -294,23 +294,23 @@ class MiLight {
     }
     if (lightbulbService.getCharacteristic(Characteristic.On)) {
       lightbulbService.getCharacteristic(Characteristic.On)
-        .on('set', this.setPowerState.bind(this));
+          .on('set', this.setPowerState.bind(this));
     }
     if (lightbulbService.getCharacteristic(Characteristic.Brightness)) {
       lightbulbService.getCharacteristic(Characteristic.Brightness)
-        .on('set', this.setBrightness.bind(this));
+          .on('set', this.setBrightness.bind(this));
     }
     if (lightbulbService.getCharacteristic(Characteristic.Saturation)) {
       lightbulbService.getCharacteristic(Characteristic.Saturation)
-        .on('set', this.setSaturation.bind(this));
+          .on('set', this.setSaturation.bind(this));
     }
     if (lightbulbService.getCharacteristic(Characteristic.Hue)) {
       lightbulbService.getCharacteristic(Characteristic.Hue)
-        .on('set', this.setHue.bind(this));
+          .on('set', this.setHue.bind(this));
     }
     if (lightbulbService.getCharacteristic(Characteristic.ColorTemperature)) {
       lightbulbService.getCharacteristic(Characteristic.ColorTemperature)
-        .on('set', this.setColorTemperature.bind(this));
+          .on('set', this.setColorTemperature.bind(this));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -480,9 +480,9 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['[getPowerState] GET Request']);
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       callback(null, returnValue.state === 'ON' || returnValue.bulb_mode === 'night');
     }
@@ -506,9 +506,9 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['[getBrightness] GET Request']);
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       if(returnValue.bulb_mode === 'night'){
         brightness = 1; //set brightness to 1 if night_mode is enabled
@@ -536,9 +536,9 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['[getHue] GET Request']);
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       if(returnValue.bulb_mode === "color"){
         var calculatedHS = this.platform.RGBtoHS(returnValue.color.r, returnValue.color.g, returnValue.color.b);
@@ -565,9 +565,9 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['[getSaturation] GET Request']);
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       if(returnValue.bulb_mode === "color"){
         var calculatedHS = this.platform.RGBtoHS(returnValue.color.r, returnValue.color.g, returnValue.color.b);
@@ -594,9 +594,9 @@ class MiLight {
       callback(null, null);
     } else {
       var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
-      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       this.platform.debugLog(['[getColorTemperature] GET Request']);
+      var returnValue = JSON.parse(await this.platform.apiCall(path));
 
       if(returnValue.bulb_mode === "color"){
         callback(null, null);

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ class MiLightHubPlatform {
     this.log = log;
     this.config = config;
     this.backchannel = config['backchannel'] || false;
+    this.forceHTTP = config['forceHTTP'] || false;
     this.debug = config['debug'] || false;
 
     // according to https://github.com/apple/HomeKitADK/blob/master/HAP/HAPCharacteristicTypes.h this is a unsupported combination:
@@ -107,7 +108,7 @@ class MiLightHubPlatform {
             platform.mqttClient = null;
           }
           // TODO: user / pass
-          if (platform.mqttServer) {
+          if (platform.mqttServer && !(platform.forceHTTP)) {
             platform.log('Using MQTT server at ' + platform.mqttServer);
             platform.mqttClient = mqtt.connect('mqtt://' + platform.mqttServer);
           } else {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class MiLightHubPlatform {
 
   getServerLightList () {
     const platform = this;
-    this.readHubSettings(this.host).then(response => {
+    this.getHttp('/settings').then(response => {
       if (response) {
         var lightList = [];
         const settings = JSON.parse(response);
@@ -152,34 +152,6 @@ class MiLightHubPlatform {
     });
   }
 
-  async readHubSettings (host) {
-    // console.log("apiCall", alias, json);
-    return new Promise(resolve => {
-      const url = 'http://' + host + '/settings';
-      const req = http.request(url, {
-        method: 'GET'
-      }, res => {
-        let recvBody = '';
-        res.on('data', chunk => {
-          recvBody += chunk;
-        });
-        res.on('end', _ => {
-          // console.log("response end, status: "+res.statusCode+" recvBody: "+recvBody);
-          if (res.statusCode === 200) {
-            resolve(recvBody);
-          } else {
-            resolve(false);
-          }
-        });
-      });
-      req.on('error', e => {
-        console.log('error sending to Milight esp hub', url, e);
-        resolve(false);
-      });
-      req.end();
-    });
-  }
-
   sendCommand (deviceId, remoteType, groupId, command) {
     if (this.mqttClient) {
       var path = this.mqttTopicPattern.replace(':device_id', deviceId).replace(':device_type', remoteType).replace(':group_id', groupId);
@@ -200,7 +172,7 @@ class MiLightHubPlatform {
 
   async sendHttp (path, json) {
     return new Promise(resolve => {
-      const url = 'http://' + this.host + '/gateways/' + path;
+      const url = 'http://' + this.host + path;
       const sendBody = JSON.stringify(json);
       const req = http.request(url, {
         method: 'PUT',
@@ -222,7 +194,7 @@ class MiLightHubPlatform {
         });
       });
       req.on('error', e => {
-        // console.log('error sending to Milight esp hub', url, json, e);
+        console.log('error sending to Milight esp hub', url, e);
         resolve(false);
       });
       req.write(sendBody);
@@ -260,8 +232,8 @@ class MiLightHubPlatform {
   //RGBtoHSV by Garry Tan from https://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c with some modifications
   RGBtoHS(r, g, b) {
     const max = Math.max(r, g, b),
-          min = Math.min(r, g, b),
-          a = max - min;
+        min = Math.min(r, g, b),
+        a = max - min;
 
     switch(max) {
       case min:
@@ -466,7 +438,7 @@ class MiLight {
       //not implemented yet so return null
       callback(null, null);
     } else {
-      var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
+      var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.getHttp(path));
 
       this.platform.debugLog(['\n', '[getPowerState] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
@@ -489,7 +461,7 @@ class MiLight {
       // not implemented yet so return null
       callback(null, null);
     } else {
-      var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
+      var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.getHttp(path));
 
       this.platform.debugLog(['\n', '[getBrightness] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
@@ -516,7 +488,7 @@ class MiLight {
       //not implemented yet so return null
       callback(null, null);
     } else {
-      var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
+      var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.getHttp(path));
 
       this.platform.debugLog(['\n', '[getHue] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
@@ -542,7 +514,7 @@ class MiLight {
       //not implemented yet so return null
       callback(null, null);
     } else {
-      var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
+      var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.getHttp(path));
 
       this.platform.debugLog(['\n', '[getSaturation] GET Request: ' + path, 'returned JSON Object: ', returnValue]);
@@ -568,7 +540,7 @@ class MiLight {
       // not implemented yet so return null
       callback(null, null);
     } else {
-      var path = '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
+      var path = '/gateways/' + '0x' + this.device_id.toString(16) + '/' + this.remote_type + '/' + this.group_id;
       var returnValue = JSON.parse(await this.platform.getHttp(path));
 
       this.platform.debugLog(['\n', '[getColorTemperature] GET Request: ' + path, 'returned JSON Object: ', returnValue]);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "mqtt": "^3.0.0"
   },
   "engines": {
-    "homebridge": "^0.4.50"
+    "homebridge": "^0.4.50",
+    "node" : ">=10.12"
   },
   "devDependencies": {
     "homebridge": "^0.4.50"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-milighthub-platform",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Homebridge plugin to control Milight lamps with Milight Hub using MQTT or HTTP",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "engines": {
     "homebridge": "^0.4.50",
-    "node" : ">=10.12"
+    "node": ">=10.12"
   },
   "devDependencies": {
     "homebridge": "^0.4.50"


### PR DESCRIPTION
#### New features
- All lamps *should* work now
- Added password support for HTTP & MQTT
- Added backchannel for HTTP & MQTT
- Added an option to force HTTP usage
- Added a debug option
- HomeKit makes a single request for a single characteristic by default. If you are getting the values like we do via MQTT subscriptions everythings is alright. 
But if you have to do a HTTP request for every single characteristic this is awful. I've added a deduplication for parallel running HTTP request-promises which speeds up things.
- `Characteristic.FirmwareRevision` now contains the version of this plugin

#### Changes
- Changed the default behaviour how this plugin works for lamps with RGB and color temperature to preserve HomeKit compatibility. 
Before it was setting Hue, Saturation and Color Temperature characteristic which is unsupported by the HAP (see [HomeKit ADK](https://github.com/apple/HomeKitADK/blob/master/HAP/HAPCharacteristicTypes.h#L2734)) 
Now it only sets Hue and Saturation characteristics but calculates the RGB values near to the color temperature values (cold white / warm white) and sets them if necessary. 
Users can choose between both modes via `rgbcctMode` option

#### Fixes
- `Characteristic.SerialNumber` was `undefined[undefined]` before, now it contains the full path of the bulbs
- `Characteristic.Model` was `null` before, now it contains some variables to determine if set characteristics are matching with the current options for this plugin
