### PR TITLE
Replace console.log by this.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # homebridge-milighthub-platform [![NPM Version](https://img.shields.io/npm/v/homebridge-milighthub-platform.svg)](https://www.npmjs.com/package/homebridge-milighthub-platform)
 Homebridge plugin to control MiLight / EULight lamps through the Open Source [MiLight Hub](https://github.com/sidoh/esp8266_milight_hub).
 
-This plugin is a WIP, check below for the current limitations.
-
 ## Features
 - Automatically fetches all MiLight Hub aliases as lights
   - Add/Remove lamps through the MiLight Hub web interface
@@ -51,4 +49,4 @@ If MQTT is configured in the MiLight Hub then the plugin will automatically read
 
 ## Limitation
 #### RGB+CCT / RGBW(W) lamps
-RGB+CCT / RGBW(W) milights have two modes, color tempurature or RGB. Unfurtunately HomeKit does not support lights with both modes, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.
+RGB+CCT / RGBW(W) milights have two modes, color tempurature and RGB. Unfurtunately HomeKit does not support lights with both modes active at the same time, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the tempurature circle in HomeKit and uses the color tempurature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class MiLightHubPlatform {
         if (i === 0) {
           this.log(debugLogDelimiter, message[i]);
         } else {
-          console.log(message[i])
+          this.log(message[i])
         }
       }
     } else {
@@ -280,9 +280,9 @@ class MiLightHubPlatform {
         });
         req.on('error', e => {
           if(json === null){
-            console.log('Error sending to MiLight ESP hub', url, json, e);
+            this.log('Error sending to MiLight ESP hub', url, json, e);
           } else {
-            console.log('Error sending to MiLight ESP hub', url, e);
+            this.log('Error sending to MiLight ESP hub', url, e);
           }
           resolve(false);
           this.cachedPromises[path] = 'new run';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-milighthub-platform",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Homebridge plugin to control Milight lamps with Milight Hub using MQTT or HTTP",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've created a review for the 'Verified By Homebridge' status, see https://github.com/homebridge/verified/issues/40

Current requirement is to replace console.log by this.log.