### PR TITLE
Add darkMode & fix non-unique mqtt clientId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For documentation please see the [README](https://github.com/normen/homebridge-m
 ## 0.3.6
 
 - use unique mqtt id
+- added darkMode
 
 ## 0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,30 @@
 # Changelog for homebridge-milighthub-platform
+
 This is the change log for the plugin, all relevant changes will be listed here.
 
 For documentation please see the [README](https://github.com/normen/homebridge-milighthub-platform/blob/master/README.md)
 
+## 0.3.6
+
+- use unique mqtt id
+
 ## 0.3.5
+
 - avoid sending hue when setting to white
 
 ## 0.3.4
+
 - small fixes
 
 ## 0.3.0
+
 - all planned features implemented (thanks Zer0x00!)
 
 ## 0.2.0
+
 - fix update order by caching sequential homekit commands
 
 ## 0.1.1
+
 - cleanup hue/sat logic
 - make night mode work

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # homebridge-milighthub-platform [![NPM Version](https://img.shields.io/npm/v/homebridge-milighthub-platform.svg)](https://www.npmjs.com/package/homebridge-milighthub-platform) [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
+
 Homebridge plugin to control MiLight / EULight lamps through the Open Source [MiLight Hub](https://github.com/sidoh/esp8266_milight_hub).
 
 ## Features
+
 - Automatically fetches all MiLight Hub aliases as lights
   - Add/Remove lamps through the MiLight Hub web interface
   - No config.json editing, no entering stuff twice
@@ -9,12 +11,14 @@ Homebridge plugin to control MiLight / EULight lamps through the Open Source [Mi
   - Using an MQTT broker can improve performance when using many lamps
 
 ## Installation
+
 1. Install homebridge using: npm install -g homebridge
 2. Install this plugin using: npm install -g homebridge-milighthub-platform
 3. Add the plugin through your config.json
 
 #### Example config
-```
+
+```json
 {
   "bridge": {
     "name": "Homebridge",
@@ -31,34 +35,53 @@ Homebridge plugin to control MiLight / EULight lamps through the Open Source [Mi
 ```
 
 #### Options
- - `host` Hostname of your MiLight Hub, default `milight-hub.local`
- - `backchannel` Enables/Disables backchannel, currently limited to http only, default `false` (disabled)
- - `rgbcctMode` Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favourite colors in Home App anymore, default `false` (disabled)
- --- further explanation at the bottom 
- - `httpUsername` If you are using a username:password authentication for your MiLight Hub type in here your credentials, default `null` (disabled)
- - `httpPassword` If you are using a username:password authentication for your MiLight Hub type in here your credentials, default `null` (disabled)
- - `forceHTTP` Force use of HTTP regardless of MQTT settings in your MiLight hub, default `false` (disabled)
- - `syncHubInterval` Defines the interval in seconds when the plugin synchronizes with the hub, default every `10` seconds
- - `commandDelay` Defines the delay to send the commands with in milliseconds, default `100` milliseconds
- - `debug` Enables/Disables debug mode, default `false` (disabled)
+
+- `host` Hostname of your MiLight Hub, default milight-hub.local`
+- `name` The name of the platform as it appears in the homebridge log, default `MiLightHubPlatform`
+- `httpUsername` If you are using a username:password authentication for your MiLight Hub type in here your credentials, default `null` (disabled)
+- `httpPassword` If you are using a username:password authentication for your MiLight Hub type in here your credentials, default `null` (disabled)
+- `backchannel` Enables/Disables backchannel, currently limited to http only, default `false` (disabled)
+- `darkMode` Enables/Disables setting a low brightness value to mitigate the bright flashing of the lights if you turn them on with a low brightness & caches the last value before power off, default `false` (disabled)
+--- see limitations
+- `rgbcctMode` Enables ColorTemperature characteristic which is unsupported by HomeKit in combination with RGB characteristics but gives you a more accurate control of your lights at the expense of not supporting favourite colors in Home App anymore, default `false` (disabled)
+ --- further explanation at the bottom
+- `forceHTTP` Force use of HTTP regardless of MQTT settings in your MiLight hub, default `false` (disabled)
+- `syncHubInterval` Defines the interval in seconds when the plugin synchronizes with the hub, default every `10` seconds
+- `commandDelay` Defines the delay to send the commands with in milliseconds, default `100` milliseconds
+- `debug` Enables/Disables debug mode, default `false` (disabled)
 
 ## Usage
+
 #### Adding/removing Lamps
+
 To add lamps in HomeKit, add aliases to the MiLight Hub. The aliases will automatically appear as lamps in HomeKit. If you remove an alias on the MiLight Hub the corresponding lamp will be removed as well.
 
 #### Using MQTT
+
 If MQTT is configured in the MiLight Hub then the plugin will automatically read those settings and use them to connect to MiLight Hub via MQTT. Make sure your MQTT topic pattern includes the `:device_id`, `:device_type` and `:group_id` values, as in the suggested default value `milight/:device_id/:device_type/:group_id`.
 
-## Limitation
+## Limitations
+
+#### darkMode flag
+
+This option changes 2 things:
+1st: It sets the brightness value to 1 when switching off, so that when switching on again the lights do not flash super bright for a short moment.
+2nd thing: It saves the last brightness value before the lights are switched off, so that when they are switched on again, they have the same value as before.
+
+Unfortunately, there's a flip side to the coin: programmatically there's no way to distinguish between switching the lights on by sliding the brightness slider to 100 and switching them on by clicking the lights button. Since the cached value overwrites your brightness setting to 100, this leads to the error that your brightness is not set to 100 and you have to repeat the process.
+
 #### RGB+CCT / RGBW(W) lamps
+
 RGB+CCT / RGBW(W) milights have two modes, color temperature and RGB. Unfortunately HomeKit does not support lights with both modes active at the same time, so it's not supported to expose both RGB and Kelvin properties to Homekit. The default mode exposes only an RGB property, but detects when you set a color that is close to the colors used in the temperature circle in HomeKit and uses the color temperature mode on the milights in this case. This way you can still make use of favourite light-settings in the Home app. If you want to expose both properties anyway you can enable the RGB+CCT mode.
 
 ## Development
-If you want new features or improve the plugin, you're very welcome to do so. The projects `devDependencies` include homebridge and the `npm run test` command has been adapted so that you can run a test instance of homebridge during development. 
-#### Setup
-- clone github repo
-- `npm install` in the project folder
-- create `.homebridge` folder in project root
-- add `config.json` with appropriate content to `.homebridge` folder
-- run `npm run test` to start the homebridge instance for testing
 
+If you want new features or improve the plugin, you're very welcome to do so. The projects `devDependencies` include homebridge and the `npm run test` command has been adapted so that you can run a test instance of homebridge during development.
+
+#### Setup
+
+- Clone github repo
+- `npm install` in the project folder
+- Create `.homebridge` folder in project root
+- Add `config.json` with appropriate content to `.homebridge` folder
+- Run `npm run test` to start the homebridge instance for testing

--- a/config.schema.json
+++ b/config.schema.json
@@ -4,18 +4,18 @@
   "headerDisplay": "Configure your lights in your [MiLight Hub](http://milight-hub.local)",
   "footerDisplay": "For documentation please see http://github.com/normen/homebridge-milighthub-platform",
   "schema": {
-    "name": {
-      "title": "Log Name",
-      "type": "string",
-      "default": "MiLightHubPlatform",
-      "description": "The name of the platform as it appears in the homebridge log",
-      "required": false
-    },
     "host": {
       "title": "Hostname",
       "type": "string",
       "default": "milight-hub.local",
       "description": "The hostname or IP address of the MiLight Hub",
+      "required": false
+    },
+    "name": {
+      "title": "Log Name",
+      "type": "string",
+      "default": "MiLightHubPlatform",
+      "description": "The name of the platform as it appears in the homebridge log",
       "required": false
     },
     "httpUsername": {
@@ -37,6 +37,13 @@
       "type": "boolean",
       "default": false,
       "description": "If enabled HomeKit will update if MiLight hub is controlled otherwise",
+      "required": false
+    },
+    "darkMode": {
+      "title": "Mitigate bright flashing of lights",
+      "type": "boolean",
+      "default": false,
+      "description": "A feature to mitigate the bright flashing of the lights if you turn them on with a low brightness value & to cache the last value before power off",
       "required": false
     },
     "rgbcctMode": {
@@ -83,14 +90,15 @@
       "expanded": false,
       "title": "Advanced",
       "items": [
+        "name",
         "httpUsername",
         "httpPassword",
         "backchannel",
+        "darkMode",
         "rgbcctMode",
         "forceHTTP",
         "syncHubInterval",
         "commandDelay",
-        "name",
         "debug"
       ]
     }

--- a/index.js
+++ b/index.js
@@ -517,6 +517,7 @@ class MiLight {
           command.level = dstate.level;
           cstate.level = dstate.level;
         } else {
+          this.accessory.getService(Service.Lightbulb).getCharacteristic(Characteristic.Brightness).updateValue(cstate.level);
           cstate.powerOffByBrightness = false;
         }
 
@@ -530,7 +531,6 @@ class MiLight {
       cstate.state = dstate.state;
       if(dstate.level === 0){
         cstate.powerOffByBrightness = true;
-        this.accessory.getService(Service.Lightbulb).getCharacteristic(Characteristic.Brightness).updateValue(cstate.level);
       }
       if (dstate.level !== undefined) {
         cstate.level = dstate.level;

--- a/index.js
+++ b/index.js
@@ -259,13 +259,15 @@ class MiLightHubPlatform {
   initializeMQTT () {
     var platform = this;
     var mqtt_options = {
-      clientId: 'homebridge_milight_hub'
+      clientId: 'homebridge_milight_hub-' + Math.random().toString(16).substr(2, 8)
     };
     if (platform.mqttUser !== '' && platform.mqttPass !== '') {
       mqtt_options.username = platform.mqttUser;
       mqtt_options.password = platform.mqttPass;
     }
     platform.mqttClient = mqtt.connect('mqtt://' + platform.mqttServer, mqtt_options);
+
+    
     if (platform.backchannel && platform.mqttClient._events.message === undefined) {
       platform.mqttClient.on('message', function (topic, message, packet) { // create a listener if no one was created yet
         platform.accessories.forEach(function (milight) {

--- a/index.js
+++ b/index.js
@@ -266,8 +266,6 @@ class MiLightHubPlatform {
       mqtt_options.password = platform.mqttPass;
     }
     platform.mqttClient = mqtt.connect('mqtt://' + platform.mqttServer, mqtt_options);
-
-    
     if (platform.backchannel && platform.mqttClient._events.message === undefined) {
       platform.mqttClient.on('message', function (topic, message, packet) { // create a listener if no one was created yet
         platform.accessories.forEach(function (milight) {

--- a/index.js
+++ b/index.js
@@ -513,8 +513,13 @@ class MiLight {
       }
       if (dstate.level > 1) {
         command.state = 'On';
-        command.level = dstate.level;
-        cstate.level = dstate.level;
+        if(!cstate.powerOffByBrightness){
+          command.level = dstate.level;
+          cstate.level = dstate.level;
+        } else {
+          cstate.powerOffByBrightness = false;
+        }
+
       } else if (dstate.level <= 1) {
         command.commands = ['night_mode'];
         cstate.level = dstate.level;
@@ -523,6 +528,10 @@ class MiLight {
     } else if (dstate.state !== undefined) {
       command.state = 'Off';
       cstate.state = dstate.state;
+      if(dstate.level === 0){
+        cstate.powerOffByBrightness = true;
+        this.accessory.getService(Service.Lightbulb).getCharacteristic(Characteristic.Brightness).updateValue(cstate.level);
+      }
       if (dstate.level !== undefined) {
         cstate.level = dstate.level;
       }

--- a/index.js
+++ b/index.js
@@ -532,9 +532,6 @@ class MiLight {
       if(dstate.level === 0){
         cstate.powerOffByBrightness = true;
       }
-      if (dstate.level !== undefined) {
-        cstate.level = dstate.level;
-      }
     }
     if (dstate.saturation !== undefined) {
       if (dstate.saturation === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-milighthub-platform",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Homebridge plugin to control Milight lamps with Milight Hub using MQTT or HTTP",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### New features
- Added darkMode to mitigate the bright flashing of lights

#### Fixes
- Fix non-unique mqtt clientId which was causing issues if you had running 2 instances connected to the same broker
- linted markdown files without changing the appearance as far as possible