### PR TITLE
Fix light flashing when night mode is activated (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,32 @@ This is the change log for the plugin, all relevant changes will be listed here.
 
 For documentation please see the [README](https://github.com/normen/homebridge-milighthub-platform/blob/master/README.md)
 
+## 0.4.1
+
+- Fix light flashing when night mode is activated (#6)
+
 ## 0.4.0
 
-- use unique mqtt id
-- added darkMode
+- Use unique mqtt id
+- Added darkMode
 
 ## 0.3.5
 
-- avoid sending hue when setting to white
+- Avoid sending hue when setting to white
 
 ## 0.3.4
 
-- small fixes
+- Small fixes
 
 ## 0.3.0
 
-- all planned features implemented (thanks Zer0x00!)
+- All planned features implemented (thanks Zer0x00!)
 
 ## 0.2.0
 
-- fix update order by caching sequential homekit commands
+- Fix update order by caching sequential homekit commands
 
 ## 0.1.1
 
-- cleanup hue/sat logic
-- make night mode work
+- Cleanup hue/sat logic
+- Make night mode work

--- a/index.js
+++ b/index.js
@@ -518,6 +518,7 @@ class MiLight {
         if (dstate.level > 1) {
           command.level = dstate.level;
         } else if (dstate.level === 1) {
+          delete command.state;
           command.commands = ['night_mode'];
         }
         cstate.level = dstate.level;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-milighthub-platform",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Homebridge plugin to control Milight lamps with Milight Hub using MQTT or HTTP",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   },
   "engines": {
     "homebridge": ">=0.4.50",
-    "node": ">=10.12"
+    "node": ">=12.19.0"
   },
   "devDependencies": {
     "homebridge": "^1.0.0"


### PR DESCRIPTION
The issue with the light flashing when night mode gets activated was because MiLight sets the state of the bulbs natively to _Off_  if night mode is activated. The ESP8266 implementation replicates this behaviour.

Currently we're sending ``
{ state: 'On', commands: [ 'night_mode' ] }
``

With this PR it is now changed to ``
{ commands: [ 'night_mode' ] }
``

I did a few tests with dark mode enabled and disabled. 
In both conditions the issue seems now to be fixed.